### PR TITLE
refactors Typescript types

### DIFF
--- a/components/ShowBody.tsx
+++ b/components/ShowBody.tsx
@@ -14,6 +14,7 @@ import {
 import Cast from "./Cast";
 import Grid from "./styled/Grid";
 import Padding from "./styled/Padding";
+import { ShowType } from "../pages/shows/[show]";
 import styled from "styled-components";
 
 type ShowHeaderProps = ColorProps &
@@ -40,15 +41,15 @@ const GridCell = styled.div<ShowHeaderProps>`
   ${flexbox}
 `;
 
-interface ShowProps {
-  schedule: { days: string[] };
-  status: string;
-  genres: string[];
-  network: string;
-  url: string;
-}
+type ShowBodyProps = Pick<
+  ShowType,
+  "schedule" | "status" | "genres" | "network" | "url"
+>;
 
-const ShowBody = (props: ShowProps) => {
+const fallbackNetwork = "Not available";
+
+const ShowBody = (props: ShowBodyProps) => {
+  const network = props.network ? props.network.name : fallbackNetwork;
   const schedule = props.schedule.days.join(", ");
   const genres = props.genres.join(", ");
   const layouts = ["flex", "flex", "flex", "contents"];
@@ -83,7 +84,7 @@ const ShowBody = (props: ShowProps) => {
               >
                 <GridCell display={layouts} flexDirection="column">
                   <ShowInfo>Streamed On</ShowInfo>
-                  <ShowInfoData color="grey">{props.network}</ShowInfoData>
+                  <ShowInfoData color="grey">{network}</ShowInfoData>
                 </GridCell>
                 <GridCell display={layouts} flexDirection="column">
                   <ShowInfo>Schedule</ShowInfo>

--- a/components/ShowHeader.tsx
+++ b/components/ShowHeader.tsx
@@ -15,26 +15,26 @@ import Rating from "./Rating";
 import { faStar } from "@fortawesome/free-solid-svg-icons";
 import styled from "styled-components";
 
-type ShowHeaderProps = TypographyProps & LayoutProps & SpaceProps;
+type HeaderProps = TypographyProps & LayoutProps & SpaceProps;
 
-const ShowSummary = styled.div<ShowHeaderProps>`
+const ShowSummary = styled.div<HeaderProps>`
   ${typography};
 `;
 
-const ShowImage = styled.img<ShowHeaderProps>`
+const ShowImage = styled.img<HeaderProps>`
   ${layout};
 `;
 
-const ShowTitle = styled.h2<ShowHeaderProps>`
+const ShowTitle = styled.h2<HeaderProps>`
   ${typography};
   ${space};
 `;
 
-const ShowLink = styled.a<ShowHeaderProps>`
+const ShowLink = styled.a<HeaderProps>`
   width: fit-content;
 `;
 
-interface ShowProps {
+interface ShowHeaderProps {
   name: string;
   image: string;
   summary: string;
@@ -42,7 +42,7 @@ interface ShowProps {
 }
 
 // TO DO replace the 5 placeholder stars on lines 57 - 61 with the result of renderFullStars()
-const ShowHeader = (props: ShowProps) => {
+const ShowHeader = (props: ShowHeaderProps) => {
   return (
     <Padding px={6} pb={[0, 0, 0, 6]}>
       <Flex flexDirection={["column", "column", "column", "row"]}>

--- a/components/Shows.tsx
+++ b/components/Shows.tsx
@@ -1,9 +1,9 @@
+import { EpisodeType } from "../pages/shows/[show]";
 import Grid from "./styled/Grid";
 import Image from "next/image";
 import Link from "next/link";
 import Padding from "./styled/Padding";
 import Rating from "./Rating";
-import { ShowType } from "../pages/shows/[show]";
 import styled from "styled-components";
 
 const Div = styled.div`
@@ -14,11 +14,14 @@ const Div = styled.div`
 
 const fallbackImage = "/assets/avatar.jpeg";
 
-const Show = ({ show, url }: ShowType) => {
+type ShowProps = EpisodeType;
+
+const Show = (props: ShowProps) => {
+  const { show } = props;
   const image = show.image ? show.image.medium : fallbackImage;
 
   return (
-    <Link as={`/shows/${show.id}`} href="/shows/[show]" key={url}>
+    <Link as={`/shows/${show.id}`} href="/shows/[show]" key={show.url}>
       <a>
         <Div>
           <Image
@@ -35,10 +38,10 @@ const Show = ({ show, url }: ShowType) => {
   );
 };
 
-type ShowsType = ShowType[];
+type EpisodesType = EpisodeType[];
 
 type ShowsProps = {
-  shows: ShowsType;
+  shows: EpisodesType;
 };
 
 const Shows = (props: ShowsProps) => {

--- a/components/core/Intro.tsx
+++ b/components/core/Intro.tsx
@@ -1,11 +1,11 @@
+import { EpisodeType } from "../../pages/shows/[show]";
 import Padding from "../styled/Padding";
-import { ShowType } from "../../pages/shows/[show]";
 import Shows from "../Shows";
 
-type ShowsType = ShowType[];
+type EpisodesType = EpisodeType[];
 
 type ShowsProps = {
-  shows: ShowsType;
+  shows: EpisodesType;
 };
 
 const Intro = ({ shows }: ShowsProps) => {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,14 +1,14 @@
 import Container from "../components/core/Container";
+import { EpisodeType } from "./shows/[show]";
 import Head from "next/head";
 import Header from "../components/core/Header";
 import Intro from "../components/core/Intro";
 import Layout from "../components/core/Layout";
-import { ShowType } from "./shows/[show]";
 
-type ShowsType = ShowType[];
+type EpisodesType = EpisodeType[];
 
 type ShowsProps = {
-  shows: ShowsType;
+  shows: EpisodesType;
 };
 
 const Home = ({ shows }: ShowsProps) => {
@@ -28,6 +28,7 @@ const Home = ({ shows }: ShowsProps) => {
 Home.getInitialProps = async () => {
   const res = await fetch("http://api.tvmaze.com/schedule?country=US");
   const json = await res.json();
+  console.log(json);
   return {
     shows: json,
   };

--- a/pages/shows/[show].tsx
+++ b/pages/shows/[show].tsx
@@ -7,28 +7,43 @@ import ShowBody from "../../components/ShowBody";
 import ShowHeader from "../../components/ShowHeader";
 import { useRouter } from "next/router";
 
+export type ShowPageProps = {
+  show: ShowType;
+};
+
+export type EpisodeType = {
+  show: ShowType;
+};
+
 export type ShowType = {
+  name: string;
+  image: { medium: string } | null;
+  summary: string;
+  rating: { average: number };
+  id: number;
+  genres: string[];
+  network: { name: string } | null;
+  status: string;
+  schedule: { days: string[] };
   url: string;
-  show: {
-    name: string;
-    image: { medium: string } | null;
-    summary: string;
-    rating: { average: number };
-    id: number;
-    genres: string[];
-    network: { name: string } | null;
-    status: string;
-    schedule: { days: string[] };
-  };
 };
 
 const fallbackImage = "/assets/avatar.jpeg";
-const fallbackNetwork = "Not available";
 
-const Show = ({ show, url }: ShowType) => {
-  const { name, summary, rating, genres, status, schedule } = show;
-  const showImage = show.image ? show.image.medium : fallbackImage;
-  const showNetwork = show.network ? show.network.name : fallbackNetwork;
+const Show = (props: ShowPageProps) => {
+  const {
+    name,
+    summary,
+    rating,
+    genres,
+    status,
+    schedule,
+    url,
+    image,
+    network,
+  } = props.show;
+
+  const showImage = image ? image.medium : fallbackImage;
 
   const router = useRouter();
   if (!router.isFallback && !name) {
@@ -55,7 +70,7 @@ const Show = ({ show, url }: ShowType) => {
               />
               <ShowBody
                 genres={genres}
-                network={showNetwork}
+                network={network}
                 schedule={schedule}
                 status={status}
                 url={url}
@@ -69,7 +84,9 @@ const Show = ({ show, url }: ShowType) => {
 };
 
 Show.getInitialProps = async (ctx: any) => {
-  const res = await fetch(`http://api.tvmaze.com/shows/${ctx.query.show}`);
+  const res = await fetch(
+    `http://api.tvmaze.com/shows/${ctx.query.show}?embed=cast`
+  );
 
   const json = await res.json();
 


### PR DESCRIPTION
### What changes have you made?
- Types have been refactored to be more human-readable i.e. `ShowType` > `EpisodeType` > `ShowPageProps` 
- All exportable types have been moved to `[show]` in order to preserve "one source of truth" 
- Types have been renamed to carry contextual meaning i.e. `ShowHeaderProps` instead of `ShowProps` 

### Which issue(s) does this PR fix?
Fixes #31 

### Screenshots (if there are design changes)
No design changes

### How to test
Open the homepage and the `[show]` page in the browser and make sure that there are no Typescript errors 

