### PR TITLE
fixes image stretch

### DIFF
--- a/components/CastList.tsx
+++ b/components/CastList.tsx
@@ -31,9 +31,16 @@ const CastListItem = styled.li<CastProps>`
   ${typography};
 `;
 
-const Avatar = styled.img<CastProps>`
-  ${border};
+const CircularPortrait = styled.div<CastProps>`
+  position: relative;
+  overflow: hidden;
+  border-radius: 50%;
   ${layout};
+`;
+
+const Avatar = styled.img<CastProps>`
+  width: 100%;
+  height: auto;
 `;
 
 const Div = styled.div<CastProps>`
@@ -70,7 +77,9 @@ const CastMember = (props: CastMemberProps) => {
     >
       <CastListItem key={props.url} fontSize={2}>
         <Flex alignItems="center">
-          <Avatar src={castImage}></Avatar>
+          <CircularPortrait width={50} height={50}>
+            <Avatar src={castImage}></Avatar>
+          </CircularPortrait>
           <P>{castMember}</P>
           <P>{characterName}</P>
         </Flex>


### PR DESCRIPTION
### What changes have you made?
- created a wrapper `div` of `CircularPortrait` with an equal `width` and `height` to encase the `img` in a perfect square 
- as the images are portrait-oriented, we assign a height of auto and width of 100%
- we don’t need to move the `img` element, because our expectation is that the subject of the photo is at the top-centre of the composition

### Which issue(s) does this PR fix?
Fixes #18 

### Screenshots (if there are design changes)
Before:

<img width="740" alt="Screenshot 2020-12-04 at 17 39 17" src="https://user-images.githubusercontent.com/53219789/101189710-af895600-3657-11eb-9361-95759335d3dc.png">

After:

<img width="493" alt="Screenshot 2020-12-04 at 17 36 49" src="https://user-images.githubusercontent.com/53219789/101189533-7b159a00-3657-11eb-91bb-cc8fb869ee37.png">

### How to test
Go to the show page and zoom in on the browser to make sure that there is no stretch on the cast list images  