### PR TITLE
reduces array size

### DIFF
--- a/components/CastList.tsx
+++ b/components/CastList.tsx
@@ -98,10 +98,11 @@ type CastListProps = { castList: CastMemberType[] };
 
 const CastList = (props: CastListProps) => {
   const { castList } = props;
+
   return (
     <div>
       Starring
-      <ul>{castList.map(CastMember)}</ul>
+      <ul>{castList.slice(0, 4).map(CastMember)}</ul>
     </div>
   );
 };


### PR DESCRIPTION
### What changes have you made?
- some shows have long lists of cast members
- reduced the number of `castList` items returned in the map function to a maximum of 4 

### Which issue(s) does this PR fix?
Fixes #35 

### Screenshots (if there are design changes)
<img width="901" alt="Screenshot 2020-12-04 at 18 04 44" src="https://user-images.githubusercontent.com/53219789/101192857-fb3dfe80-365b-11eb-92ae-5bb51a7ea158.png">


### How to test
Select a few shows at random and check that there are no cast lists with a list of cast members longer than 4 