### PR TITLE
adds sort import rule to es lint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,9 +25,15 @@ module.exports = {
     "linebreak-style": ["error", "unix"],
     quotes: ["error", "double"],
     semi: ["error", "always"],
-  },
-  rules: {
     "react/react-in-jsx-scope": "off",
+    "sort-imports": [
+      2,
+      {
+        ignoreCase: false,
+        ignoreMemberSort: false,
+        memberSyntaxSortOrder: ["none", "all", "multiple", "single"],
+      },
+    ],
   },
   globals: {
     React: "writable",


### PR DESCRIPTION
### What changes have you made?
- needed to add some `sort-import` ruling to the `.eslintrc.js` to ensure its part of the codebase

### Which issue(s) does this PR fix?
Fixes #16 

### Screenshots (if there are design changes)
No design changes

### How to test
Navigate through the codebase and make sure that imports are sorted by the following rules:
- case-sensitive of the imports local name
- grouping of multiple-member import declarations 
- imports are sorted by their member syntax, the order is as follows: 
`none` - import module without exported bindings.
`all` - import all members provided by exported bindings.
`multiple` - import multiple members.
`single` - import single member.
