### PR TITLE
adds try/catch to fetch requests

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -8,7 +8,7 @@ import Layout from "../components/core/Layout";
 type EpisodesType = EpisodeType[];
 
 type ShowsProps = {
-  shows: EpisodesType;
+  shows: EpisodesType | null;
 };
 
 const Home = ({ shows }: ShowsProps) => {
@@ -19,19 +19,25 @@ const Home = ({ shows }: ShowsProps) => {
       </Head>
       <Container>
         <Header />
-        <Intro shows={shows} />
+        {shows ? <Intro shows={shows} /> : "sorry!"}
       </Container>
     </Layout>
   );
 };
 
 Home.getInitialProps = async () => {
-  const res = await fetch("http://api.tvmaze.com/schedule?country=US");
-  const json = await res.json();
-  console.log(json);
-  return {
-    shows: json,
-  };
+  try {
+    throw new Error();
+
+    const res = await fetch("http://api.tvmaze.com/schedule?country=US");
+    const json = await res.json();
+
+    return {
+      shows: json,
+    };
+  } catch (error) {
+    return { shows: null };
+  }
 };
 
 export default Home;

--- a/pages/shows/[show].tsx
+++ b/pages/shows/[show].tsx
@@ -1,4 +1,5 @@
-import { CastMemberType } from "../../components/CastList";
+import CastList, { CastMemberType } from "../../components/CastList";
+
 import Container from "../../components/core/Container";
 import ErrorPage from "next/error";
 import Head from "next/head";
@@ -9,8 +10,8 @@ import ShowHeader from "../../components/ShowHeader";
 import { useRouter } from "next/router";
 
 export type ShowPageProps = {
-  show: ShowType;
-  castList: CastMemberType[];
+  show: ShowType | null;
+  castList: CastMemberType[] | null;
 };
 
 export type EpisodeType = {
@@ -33,6 +34,9 @@ export type ShowType = {
 const fallbackImage = "/assets/avatar.jpeg";
 
 const Show = (props: ShowPageProps) => {
+  if (!props.show || !props.castList) {
+    return "Sorry, there was an error getting the data here";
+  }
   const {
     name,
     summary,
@@ -87,28 +91,32 @@ const Show = (props: ShowPageProps) => {
 };
 
 Show.getInitialProps = async (ctx: any) => {
-  const res = await fetch(
-    `http://api.tvmaze.com/shows/${ctx.query.show}?embed=cast`
-  );
+  try {
+    const res = await fetch(
+      `http://api.tvmaze.com/shows/${ctx.query.show}?embed=cast`
+    );
 
-  const json = await res.json();
+    const json = await res.json();
 
-  const cast = json._embedded ? json._embedded.cast : [];
+    const cast = json._embedded ? json._embedded.cast : [];
 
-  return {
-    show: {
-      name: json.name,
-      image: json.image,
-      summary: json.summary,
-      rating: json.rating,
-      genres: json.genres,
-      network: json.network,
-      schedule: json.schedule,
-      status: json.status,
-      url: json.url,
-    },
-    castList: cast,
-  };
+    return {
+      show: {
+        name: json.name,
+        image: json.image,
+        summary: json.summary,
+        rating: json.rating,
+        genres: json.genres,
+        network: json.network,
+        schedule: json.schedule,
+        status: json.status,
+        url: json.url,
+      },
+      castList: cast,
+    };
+  } catch (error) {
+    return { show: null, castList: null };
+  }
 };
 
 export default Show;


### PR DESCRIPTION
### What changes have you made?
a `try` `catch` statement has been implemented on both the fetch statements of `[show]` and `index`  as follows:

[show]: 
- if there is no data then `catch(error)` and return `{ show: null, castList: null }`
- an `if` statement has been created so that if there is no `show` **or** no `castList` then return an error message 

index: 
- if there is no data then `shows` returns `null` 
- due to the difference in tree structure compared to the `Show` component, a conditional operator has been used inside of the `Intro` component so that if there _are_ `shows`, then render `Intro`, else render an error message 

### Typescript
 the typecast of  `ShowPageProps` has been  updated so that: 
- `show` has a type of `ShowType` **or** `null`  and  `castList` has a type of `CastMemberType[]` **or** `null` 

 the typecast of  `ShowsProps` has been  updated so that: 
-   `shows` has a type of `EpisodesTypes` **or** `null` 

### Which issue(s) does this PR fix?
Fixes #39 

### Screenshots (if there are design changes)
<img width="353" alt="Screenshot 2020-12-06 at 10 45 22" src="https://user-images.githubusercontent.com/53219789/101277453-ddd07800-37b4-11eb-93ae-94e8f3195618.png">
<img width="209" alt="Screenshot 2020-12-06 at 10 44 48" src="https://user-images.githubusercontent.com/53219789/101277458-e163ff00-37b4-11eb-9f9c-e64c31da5e73.png">


### How to test
In all instances where a fetch request is used an error message should render. 

In the codebase test `throw new Error();` inside of:
- the `try` statement of the `[show]` page
- the `try` statement of the `index` page 

Make sure an error message appears for both pages and then remove the `throw new Error` to render the content again
