### PR TITLE
So/squash console errors

### DIFF
--- a/components/CastList.tsx
+++ b/components/CastList.tsx
@@ -61,9 +61,8 @@ const Div = styled.div<CastProps>`
 type CastMemberProps = CastMemberType;
 
 export type CastMemberType = {
-  person: { name: string; image: { medium: string } };
+  person: { name: string; image: { medium: string }; id: number };
   character: { name: string } | null;
-  url: string;
 };
 const fallbackName = "not available";
 const fallbackImage = "/assets/avatar.jpeg";
@@ -76,7 +75,7 @@ const CastMember = (props: CastMemberProps) => {
     : fallbackImage;
 
   return (
-    <Flex alignItems="center">
+    <Flex alignItems="center" key={props.person.id}>
       <CastListItem>
         <Grid
           gridTemplateColumns={[
@@ -86,7 +85,6 @@ const CastMember = (props: CastMemberProps) => {
             "100px 150px 100px",
           ]}
           my={1}
-          key={props.url}
         >
           <CircularPortrait width={50} height={50}>
             <Avatar src={castImage}></Avatar>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -28,9 +28,18 @@ const Home = ({ shows }: ShowsProps) => {
 Home.getInitialProps = async () => {
   const res = await fetch("http://api.tvmaze.com/schedule?country=US");
   const json = await res.json();
-  console.log(json);
+
+  // de-duplicating episodes thanks to:
+  // https://dev.to/matthewoates/comment/8hdm
+  const seen = new Set();
+  const filteredEpisodes = json.filter((episode: EpisodeType) => {
+    const duplicate = seen.has(episode.show.id);
+    seen.add(episode.show.id);
+    return !duplicate;
+  });
+
   return {
-    shows: json,
+    shows: filteredEpisodes,
   };
 };
 


### PR DESCRIPTION
### What changes have you made?
 Fixed a console error in the browser as a result of #32 :
- setting a unique key for the parent element of the `Show` component of `Shows`

The solution here was to remove duplicate instances of the same show i.e. shows with more than one episode. The `shows` data, therefore, goes through a de-duplication at the very first interaction of the `json` which is in the `index`. 

Line of attack: Remove any duplicates in the Array of Objects using Sets

Solution: First we create a `new Set()` called `seen`.  We then filter the `json` array and do a duplicate check using `has`, taking the `episode.show.id` as an argument. We then add to the Set using `add` and return `!duplicate` meaning everything that has not appeared in the Set more than once. 

### Which issue(s) does this PR fix?
Fixes #17 

### Screenshots (if there are design changes)
No design changes

### How to test
Go to localhost:3000 and open up the console. Check that there are **0** errors on both the homepage and the show view.
It should look squeaky clean, like this..

<img width="1426" alt="Screenshot 2020-12-06 at 11 28 28" src="https://user-images.githubusercontent.com/53219789/101278188-19217580-37ba-11eb-9e9d-cbdee0756ed7.png">
