### PR TITLE
adds star rating functionality

### DIFF
--- a/components/Rating.tsx
+++ b/components/Rating.tsx
@@ -1,4 +1,4 @@
-import { SpaceProps, TypographyProps, space, typography } from "styled-system";
+import { TypographyProps, typography } from "styled-system";
 
 import Flex from "./styled/Flex";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -9,14 +9,17 @@ interface ShowProps {
   rating: { average: number | null };
 }
 
-const NumberRating = styled.p<TypographyProps & SpaceProps>`
+const NoRating = styled.p<TypographyProps>`
   ${typography};
-  ${space};
+`;
+
+const NumberRating = styled.p<TypographyProps>`
+  ${typography};
 `;
 
 const Rating = (props: ShowProps) => {
   if (props.rating.average === null) {
-    return <NumberRating fontSize={1}>No rating</NumberRating>;
+    return <NoRating fontSize={1}>No rating</NoRating>;
   }
   const rating = Math.round(props.rating.average / 2);
   const maxRating = 5;

--- a/components/Rating.tsx
+++ b/components/Rating.tsx
@@ -6,7 +6,7 @@ import { faStar } from "@fortawesome/free-solid-svg-icons";
 import styled from "styled-components";
 
 interface ShowProps {
-  rating: { average: number };
+  rating: { average: number | null };
 }
 
 const NumberRating = styled.p<TypographyProps & SpaceProps>`
@@ -15,31 +15,34 @@ const NumberRating = styled.p<TypographyProps & SpaceProps>`
 `;
 
 const Rating = (props: ShowProps) => {
+  if (props.rating.average === null) {
+    return <NumberRating fontSize={1}>No rating</NumberRating>;
+  }
   const rating = Math.round(props.rating.average / 2);
   const maxRating = 5;
   const emptyStars = maxRating - rating;
 
   const renderFullStars = () => {
     return rating !== 0
-      ? Array(rating).map(index => {
-          return (
-            <FontAwesomeIcon key={`fs${index}`} icon={faStar} color="grey" />
-          );
-        })
+      ? Array(rating)
+          .fill(null)
+          .map((star, i) => {
+            return (
+              <FontAwesomeIcon key={`fs${i}`} icon={faStar} color="grey" />
+            );
+          })
       : "";
   };
 
   const renderEmptyStars = () => {
     return emptyStars !== 0
-      ? Array(emptyStars).map(index => {
-          return (
-            <FontAwesomeIcon
-              key={`es${index}`}
-              icon={faStar}
-              color="lightGrey"
-            />
-          );
-        })
+      ? Array(emptyStars)
+          .fill(null)
+          .map((star, i) => {
+            return (
+              <FontAwesomeIcon key={`es${i}`} icon={faStar} color="lightGrey" />
+            );
+          })
       : "";
   };
 

--- a/components/ShowHeader.tsx
+++ b/components/ShowHeader.tsx
@@ -53,13 +53,6 @@ const ShowHeader = (props: ShowHeaderProps) => {
         </Link>
         <Flex flexDirection="column" my={4} p={[0, 0, 0, 4]}>
           <Flex flexDirection={["column", "row", "row", "row"]}>
-            <Flex mr={4}>
-              <FontAwesomeIcon icon={faStar} color="grey" />
-              <FontAwesomeIcon icon={faStar} color="grey" />
-              <FontAwesomeIcon icon={faStar} color="grey" />
-              <FontAwesomeIcon icon={faStar} color="lightGrey" />
-              <FontAwesomeIcon icon={faStar} color="lightGrey" />
-            </Flex>
             <Rating rating={props.rating} />
           </Flex>
           <ShowTitle fontSize={4} my={4}>


### PR DESCRIPTION
### What changes have you made?
- refactored the `Rating` component so that `renderFullStars` and `renderEmptyStars` both render the correct number of stars 
- adjusted the typecast of rating so that  `rating` can be `null` in the event there is no rating 
- implemented an if statement at the top of the `Rating` component in order to differentiate between no rating and a rating of 0/5
 
### Which issue(s) does this PR fix?
Fixes #6 

### Screenshots (if there are design changes)
<img width="238" alt="Screenshot 2020-12-06 at 12 05 22" src="https://user-images.githubusercontent.com/53219789/101278412-605c3600-37bb-11eb-98d5-c0fe139aa7e5.png">

### How to test
- Go to the homepage and check that every show has either a rating or a "No rating"
- Select a few shows at random and on click, check that there is either a rating or a "No rating" 
- The number ratings have been left in for QA purposes. Use the number rating to check that the number of dark grey stars is equal to its rating value out of 5