### PR TITLE
abstracts show info from show body component

### DIFF
--- a/components/Intro.tsx
+++ b/components/Intro.tsx
@@ -1,0 +1,31 @@
+import { EpisodeType } from "../pages/shows/[episode]";
+import Padding from "./styles/Padding";
+import Shows from "./Shows";
+
+type EpisodesType = EpisodeType[];
+
+type ShowsProps = {
+  shows: EpisodesType;
+};
+
+const Intro = ({ shows }: ShowsProps) => {
+  return (
+    <section>
+      <Padding px={6} pb={4}>
+        <h3>
+          TV Show and web series database. Create personalised schedules.
+          Episode guide, cast, crew and character information.
+        </h3>
+      </Padding>
+
+      <section>
+        <Padding px={6} pb={4}>
+          <h4>Last Added Shows</h4>
+        </Padding>
+        <Shows shows={shows} />
+      </section>
+    </section>
+  );
+};
+
+export default Intro;

--- a/components/ShowBody.tsx
+++ b/components/ShowBody.tsx
@@ -1,61 +1,17 @@
 import CastList, { CastMemberType } from "./CastList";
-import {
-  ColorProps,
-  FlexboxProps,
-  GridProps,
-  LayoutProps,
-  SpaceProps,
-  color,
-  flexbox,
-  grid,
-  layout,
-  space,
-} from "styled-system";
 
-import Grid from "./styled/Grid";
-import Padding from "./styled/Padding";
+import Grid from "./styles/Grid";
+import Padding from "./styles/Padding";
+import React from "react";
+import ShowInfo from "./ShowInfo";
 import { ShowType } from "../pages/shows/[show]";
-import styled from "styled-components";
 
-type ShowHeaderProps = ColorProps &
-  LayoutProps &
-  SpaceProps &
-  GridProps &
-  FlexboxProps;
-
-const ShowInfoContainer = styled.div<ShowHeaderProps>`
-  ${space};
-`;
-
-const ShowInfo = styled.li<ShowHeaderProps>`
-  text-align: left;
-`;
-
-const ShowInfoData = styled.p<ShowHeaderProps>`
-  ${color};
-  ${grid};
-`;
-
-const GridCell = styled.div<ShowHeaderProps>`
-  ${layout};
-  ${flexbox}
-`;
-
-type ShowBodyProps = Pick<
-  ShowType,
-  "schedule" | "status" | "genres" | "network" | "url"
-> & {
+type ShowBodyProps = {
+  show: ShowType;
   castList: CastMemberType[];
 };
 
-const fallbackNetwork = "Not available";
-
 const ShowBody = (props: ShowBodyProps) => {
-  const network = props.network ? props.network.name : fallbackNetwork;
-  const schedule = props.schedule.days.join(", ");
-  const genres = props.genres.join(", ");
-  const layouts = ["flex", "flex", "flex", "contents"];
-
   return (
     <Padding px={6}>
       <Grid
@@ -68,43 +24,13 @@ const ShowBody = (props: ShowBodyProps) => {
         gridColumnGap={4}
       >
         <Grid>
-          <ShowInfoContainer my={[0, 4, 4, 0]}>
-            <h3>Show Info</h3>
-            <ul>
-              <Grid
-                gridTemplateColumns={["repeat(1, 50% [col-start])", "30% 50%"]}
-                gridTemplateRows={[
-                  "repeat(1, 1fr [row-start])",
-                  "repeat(2, 50% [row-start])",
-                  "repeat(2, 50% [row-start])",
-                  "repeat(4, 1fr [row-start])",
-                ]}
-                fontSize={2}
-                gridRowGap={[4, 4, 2, 2]}
-                gridColumnGap={4}
-                my={4}
-              >
-                <GridCell display={layouts} flexDirection="column">
-                  <ShowInfo>Streamed On</ShowInfo>
-                  <ShowInfoData color="grey">{network}</ShowInfoData>
-                </GridCell>
-                <GridCell display={layouts} flexDirection="column">
-                  <ShowInfo>Schedule</ShowInfo>
-                  <ShowInfoData color="grey" gridColumn={2}>
-                    {schedule}
-                  </ShowInfoData>
-                </GridCell>
-                <GridCell display={layouts} flexDirection="column">
-                  <ShowInfo>Status</ShowInfo>
-                  <ShowInfoData color="grey">{props.status}</ShowInfoData>
-                </GridCell>
-                <GridCell display={layouts} flexDirection="column">
-                  <ShowInfo>Genres</ShowInfo>
-                  <ShowInfoData color="grey">{genres}</ShowInfoData>
-                </GridCell>
-              </Grid>
-            </ul>
-          </ShowInfoContainer>
+          <ShowInfo
+            schedule={props.show.schedule}
+            url={props.show.url}
+            status={props.show.status}
+            genres={props.show.genres}
+            network={props.show.network}
+          />
         </Grid>
 
         <Grid gridColumn={[1, 1, 1, 2]} gridRow={[2, 2, 2, 1]} mb={8}>

--- a/components/ShowInfo.tsx
+++ b/components/ShowInfo.tsx
@@ -1,0 +1,97 @@
+import {
+  ColorProps,
+  FlexboxProps,
+  GridProps,
+  LayoutProps,
+  SpaceProps,
+  color,
+  flexbox,
+  grid,
+  layout,
+  space,
+} from "styled-system";
+
+import Grid from "./styles/Grid";
+import React from "react";
+import { ShowType } from "../pages/shows/[show]";
+import styled from "styled-components";
+
+type BodyProps = ColorProps &
+  LayoutProps &
+  SpaceProps &
+  GridProps &
+  FlexboxProps;
+
+const ShowInfoContainer = styled.div<BodyProps>`
+  ${space};
+`;
+
+const ShowInfoListItem = styled.li<BodyProps>`
+  text-align: left;
+`;
+
+const ShowInfoData = styled.p<BodyProps>`
+  ${color};
+  ${grid};
+`;
+
+const GridCell = styled.div<BodyProps>`
+  ${layout};
+  ${flexbox}
+`;
+
+type ShowInfoProps = Pick<
+  ShowType,
+  "schedule" | "status" | "genres" | "network" | "url"
+>;
+
+const fallbackNetwork = "Not available";
+
+const ShowInfo = (props: ShowInfoProps) => {
+  const network = props.network ? props.network.name : fallbackNetwork;
+  const schedule = props.schedule.days.join(", ");
+  const genres = props.genres.join(", ");
+  const layouts = ["flex", "flex", "flex", "contents"];
+
+  return (
+    <ShowInfoContainer my={[0, 4, 4, 0]}>
+      <h3>Show Info</h3>
+      <ul>
+        <Grid
+          gridTemplateColumns={["repeat(1, 50% [col-start])", "30% 50%"]}
+          gridTemplateRows={[
+            "repeat(1, 1fr [row-start])",
+            "repeat(2, 50% [row-start])",
+            "repeat(2, 50% [row-start])",
+            "repeat(4, 1fr [row-start])",
+          ]}
+          fontSize={2}
+          gridRowGap={[4, 4, 2, 2]}
+          gridColumnGap={4}
+          my={4}
+        >
+          <GridCell display={layouts} flexDirection="column">
+            <ShowInfoListItem>Streamed On</ShowInfoListItem>
+            <ShowInfoData color="grey">{network}</ShowInfoData>
+          </GridCell>
+          <GridCell display={layouts} flexDirection="column">
+            <ShowInfoListItem>Schedule</ShowInfoListItem>
+            <ShowInfoData color="grey" gridColumn={2}>
+              {schedule}
+            </ShowInfoData>
+          </GridCell>
+          <GridCell display={layouts} flexDirection="column">
+            <ShowInfoListItem>Status</ShowInfoListItem>
+            <ShowInfoData color="grey">{props.status}</ShowInfoData>
+          </GridCell>
+          <GridCell display={layouts} flexDirection="column">
+            <ShowInfoListItem>Genres</ShowInfoListItem>
+            <ShowInfoData color="grey">{genres}</ShowInfoData>
+          </GridCell>
+        </Grid>
+      </ul>
+    </ShowInfoContainer>
+  );
+};
+
+export default ShowInfo;

--- a/pages/shows/[show].tsx
+++ b/pages/shows/[show].tsx
@@ -1,5 +1,4 @@
-import CastList, { CastMemberType } from "../../components/CastList";
-
+import { CastMemberType } from "../../components/CastList";
 import Container from "../../components/core/Container";
 import ErrorPage from "next/error";
 import Head from "next/head";
@@ -37,17 +36,7 @@ const Show = (props: ShowPageProps) => {
   if (!props.show || !props.castList) {
     return "Sorry, there was an error getting the data here";
   }
-  const {
-    name,
-    summary,
-    rating,
-    genres,
-    status,
-    schedule,
-    url,
-    image,
-    network,
-  } = props.show;
+  const { name, summary, rating, image } = props.show;
 
   const showImage = image ? image.medium : fallbackImage;
 
@@ -74,14 +63,7 @@ const Show = (props: ShowPageProps) => {
                 summary={summary}
                 rating={rating}
               />
-              <ShowBody
-                genres={genres}
-                network={network}
-                schedule={schedule}
-                status={status}
-                url={url}
-                castList={props.castList}
-              />
+              <ShowBody show={props.show} castList={props.castList} />
             </article>
           </>
         )}


### PR DESCRIPTION
### What changes have you made?
- The `ShowBody` component had some confusing naming on its styled-components 
- Instead of simply renaming and to limit any future crossover the `ShowBody` component has now been abstracted into `ShowInfo` 
- The `ShowInfo` is now its own component which can be imported in the same way as `CastList`

### Which issue(s) does this PR fix?
Fixes #52 

### Screenshots (if there are design changes)
No design changes

### How to test
In the browser: 

- open the homepage and click through to the show page. 
- make sure this new insertion to the React tree doesn't throw any errors by way of incorrect pathname or missing props 