### PR TITLE
rename types styled components

### DIFF
--- a/components/CastList.tsx
+++ b/components/CastList.tsx
@@ -19,7 +19,7 @@ import Flex from "./styles/Flex";
 import Grid from "./styles/Grid";
 import styled from "styled-components";
 
-type CastProps = BorderProps &
+type StyledComponentProps = BorderProps &
   LayoutProps &
   SpaceProps &
   TypographyProps &
@@ -27,24 +27,24 @@ type CastProps = BorderProps &
   GridProps &
   FlexboxProps;
 
-const CastListItem = styled.li<CastProps>`
+const CastListItem = styled.li<StyledComponentProps>`
   ${layout};
   ${flexbox};
 `;
 
-const CircularPortrait = styled.div<CastProps>`
+const CircularPortrait = styled.div<StyledComponentProps>`
   position: relative;
   overflow: hidden;
   border-radius: 50%;
   ${layout};
 `;
 
-const Avatar = styled.img<CastProps>`
+const Avatar = styled.img<StyledComponentProps>`
   width: 100%;
   height: auto;
 `;
 
-const P = styled.p<CastProps>`
+const P = styled.p<StyledComponentProps>`
   ${typography};
   ${color};
   ${space};
@@ -53,7 +53,7 @@ const P = styled.p<CastProps>`
   align-self: center;
 `;
 
-const Div = styled.div<CastProps>`
+const Div = styled.div<StyledComponentProps>`
   ${border};
   ${layout};
 `;

--- a/components/ShowHeader.tsx
+++ b/components/ShowHeader.tsx
@@ -15,22 +15,22 @@ import Rating from "./Rating";
 import { faStar } from "@fortawesome/free-solid-svg-icons";
 import styled from "styled-components";
 
-type HeaderProps = TypographyProps & LayoutProps & SpaceProps;
+type StyledComponentProps = TypographyProps & LayoutProps & SpaceProps;
 
-const ShowSummary = styled.div<HeaderProps>`
+const ShowSummary = styled.div<StyledComponentProps>`
   ${typography};
 `;
 
-const ShowImage = styled.img<HeaderProps>`
+const ShowImage = styled.img<StyledComponentProps>`
   ${layout};
 `;
 
-const ShowTitle = styled.h2<HeaderProps>`
+const ShowTitle = styled.h2<StyledComponentProps>`
   ${typography};
   ${space};
 `;
 
-const ShowLink = styled.a<HeaderProps>`
+const ShowLink = styled.a<StyledComponentProps>`
   width: fit-content;
 `;
 

--- a/components/ShowInfo.tsx
+++ b/components/ShowInfo.tsx
@@ -16,26 +16,26 @@ import React from "react";
 import { ShowType } from "../pages/shows/[show]";
 import styled from "styled-components";
 
-type BodyProps = ColorProps &
+type StyledComponentProps = ColorProps &
   LayoutProps &
   SpaceProps &
   GridProps &
   FlexboxProps;
 
-const ShowInfoContainer = styled.div<BodyProps>`
+const ShowInfoContainer = styled.div<StyledComponentProps>`
   ${space};
 `;
 
-const ShowInfoListItem = styled.li<BodyProps>`
+const ShowInfoListItem = styled.li<StyledComponentProps>`
   text-align: left;
 `;
 
-const ShowInfoData = styled.p<BodyProps>`
+const ShowInfoData = styled.p<StyledComponentProps>`
   ${color};
   ${grid};
 `;
 
-const GridCell = styled.div<BodyProps>`
+const GridCell = styled.div<StyledComponentProps>`
   ${layout};
   ${flexbox}
 `;


### PR DESCRIPTION
### What changes have you made?
- On first take all styled-component types were renamed to `StyledComponentProps` 
- Although clear in its purpose, this isn't particularly typesafe as we're saying that some components can expect some props when they shouldn't, for example `Avatar` is not going to be passed any styled system props
- Types have now been implemented in-line in order to pass only the style group that the styled component explicitly needs 

### Which issue(s) does this PR fix?
Fixes #54 

### Screenshots (if there are design changes)
No design changes

### How to test
In the codebase, use the return statement to check that all styled-components are passed only the styled system props that it needs, if any