### PR TITLE
fixes cast list width on all devices

### DIFF
--- a/components/CastList.tsx
+++ b/components/CastList.tsx
@@ -17,6 +17,7 @@ const CircularPortrait = styled.div<LayoutProps>`
   position: relative;
   overflow: hidden;
   border-radius: 50%;
+  align-self: center;
   ${layout};
 `;
 
@@ -58,10 +59,10 @@ const CastMember = (props: CastMemberProps) => {
       <li>
         <Grid
           gridTemplateColumns={[
-            "75px 125px 100px",
-            "75px 125px 100px",
-            "75px 125px 100px",
-            "100px 150px 100px",
+            "65px 120px 120px",
+            "65px 95px 130px",
+            "65px 95px 120px",
+            "75px 150px 180px",
           ]}
           my={1}
         >

--- a/components/ShowBody.tsx
+++ b/components/ShowBody.tsx
@@ -13,13 +13,13 @@ type ShowBodyProps = {
 
 const ShowBody = (props: ShowBodyProps) => {
   return (
-    <Padding px={6}>
+    <Padding px={[3, 3, 3, 6]}>
       <Grid
         gridTemplateColumns={[
           "repeat(1, 100% [col-start])",
           "repeat(1, 100% [col-start])",
           "repeat(1, 100% [col-start])",
-          "repeat(2, 50% [col-start])",
+          "repeat(2, 40% [col-start])",
         ]}
         gridColumnGap={4}
       >

--- a/components/ShowHeader.tsx
+++ b/components/ShowHeader.tsx
@@ -39,7 +39,7 @@ interface ShowHeaderProps {
 
 const ShowHeader = (props: ShowHeaderProps) => {
   return (
-    <Padding px={6} pb={[0, 0, 0, 6]}>
+    <Padding px={[3, 3, 3, 6]} pb={[0, 0, 0, 6]}>
       <Flex flexDirection={["column", "column", "column", "row"]}>
         <Link href="/">
           <ShowLink>

--- a/components/core/Header.tsx
+++ b/components/core/Header.tsx
@@ -3,7 +3,7 @@ import Padding from "../styles/Padding";
 
 const Header = () => {
   return (
-    <Padding p={6}>
+    <Padding p={[3, 3, 3, 6]}>
       <h2>
         <Link href="/">
           <a>


### PR DESCRIPTION
### What changes have you made?
- increased the column widths of the cast list grid in order to prevent overflow on longer character names 
- added responsive padding in the `Header`, `ShowHeader` and `ShowBody` components in order to allow for more column space on smaller screen sizes

### Which issue(s) does this PR fix?
Fixes #59 

### Screenshots (if there are design changes)
Before: 

<img width="515" alt="Screenshot 2020-12-06 at 17 39 06" src="https://user-images.githubusercontent.com/53219789/101286299-f7d87d80-37e9-11eb-9f3b-e00a79f58574.png">


After: 

<img width="515" alt="Screenshot 2020-12-06 at 17 37 05" src="https://user-images.githubusercontent.com/53219789/101286247-b051f180-37e9-11eb-9ee2-f38c20645d4b.png">

### How to test
Select a few shows at random and check that the name and character name display without significant overflow on all screen sizes