### PR TITLE
changes p tag colour

### DIFF
--- a/components/CastList.tsx
+++ b/components/CastList.tsx
@@ -1,9 +1,11 @@
 import {
   BorderProps,
+  ColorProps,
   GridProps,
   LayoutProps,
   TypographyProps,
   border,
+  color,
   grid,
   layout,
   typography,
@@ -26,9 +28,10 @@ const Avatar = styled.img`
   height: auto;
 `;
 
-const P = styled.p<TypographyProps & GridProps>`
+const P = styled.p<TypographyProps & GridProps & ColorProps>`
   ${typography};
   ${grid};
+  ${color};
   display: flex;
   align-self: center;
 `;
@@ -72,7 +75,7 @@ const CastMember = (props: CastMemberProps) => {
           <P gridColumn={2} fontSize={2}>
             {castMember}
           </P>
-          <P gridColumn={3} fontSize={2}>
+          <P gridColumn={3} fontSize={2} color="grey">
             {characterName}
           </P>
         </Grid>


### PR DESCRIPTION
### What changes have you made?
- Changed the colour of the `p` tag nesting the `characterName` in the `CastList` 

### Which issue(s) does this PR fix?
Fixes #61 

### Screenshots (if there are design changes)
<img width="280" alt="Screenshot 2020-12-06 at 17 46 16" src="https://user-images.githubusercontent.com/53219789/101286507-2acf4100-37eb-11eb-880b-1a788bee88bc.png">

### How to test
Go to the show page and check that the character name is displaying in a lighter grey 