### PR TITLE
So/hide star rating

### DIFF
--- a/components/Rating.tsx
+++ b/components/Rating.tsx
@@ -46,7 +46,6 @@ const Rating = (props: RatingProps) => {
   const roundedAverage = Math.round(average / 2);
   const emptyStars = maxRating - roundedAverage;
 
-  // TO DO all ratings equal to zero display as an integer not 0.0
   const rating = average === 0 ? roundedAverage : average.toFixed(1);
 
   const renderFullStars = () => {

--- a/components/Rating.tsx
+++ b/components/Rating.tsx
@@ -1,10 +1,8 @@
-import { SpaceProps, TypographyProps, space, typography } from "styled-system";
+import { TypographyProps, typography } from "styled-system";
 
-import Flex from "./styles/Flex";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faStar } from "@fortawesome/free-solid-svg-icons";
 import styled from "styled-components";
-import { useRouter } from "next/router";
 
 interface ShowProps {
   rating: { average: number | null };
@@ -14,18 +12,7 @@ const NoRating = styled.p<TypographyProps>`
   ${typography};
 `;
 
-const NumberRating = styled.p<TypographyProps & SpaceProps>`
-  ${typography};
-  ${space};
-`;
-
 const Rating = (props: ShowProps) => {
-  const location = useRouter();
-  const hideRating = "/";
-
-  if (hideRating.includes(location.pathname)) {
-    return null;
-  }
   if (props.rating.average === null) {
     return <NoRating fontSize={1}>No rating</NoRating>;
   }
@@ -62,14 +49,10 @@ const Rating = (props: ShowProps) => {
   };
 
   return (
-    <Flex flexDirection="row">
-      {" "}
+    <div>
       <span>{renderFullStars()}</span>
       <span>{renderEmptyStars()}</span>
-      <NumberRating fontSize={1} mx={2}>
-        {rating} / 5
-      </NumberRating>
-    </Flex>
+    </div>
   );
 };
 

--- a/components/Rating.tsx
+++ b/components/Rating.tsx
@@ -1,32 +1,57 @@
-import { TypographyProps, typography } from "styled-system";
+import {
+  FlexboxProps,
+  LayoutProps,
+  SpaceProps,
+  TypographyProps,
+  flexbox,
+  layout,
+  space,
+  typography,
+} from "styled-system";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import React from "react";
 import { faStar } from "@fortawesome/free-solid-svg-icons";
 import styled from "styled-components";
 
-interface ShowProps {
+interface RatingProps {
   rating: { average: number | null };
+  display?: string[];
+  showNumbers?: boolean;
 }
 
 const NoRating = styled.p<TypographyProps>`
   ${typography};
 `;
 
-const Rating = (props: ShowProps) => {
+const RatingContainer = styled.div<LayoutProps & SpaceProps & FlexboxProps>`
+  display: flex;
+  ${layout};
+  ${space};
+  ${flexbox};
+`;
+
+const NumberRating = styled.p<TypographyProps & SpaceProps>`
+  ${typography};
+  ${space};
+`;
+
+const Rating = (props: RatingProps) => {
   if (props.rating.average === null) {
     return <NoRating fontSize={1}>No rating</NoRating>;
   }
 
-  const rating = Math.round(props.rating.average / 2);
+  const average = props.rating.average / 2;
   const maxRating = 5;
-  const emptyStars = maxRating - rating;
+  const roundedAverage = Math.round(average / 2);
+  const emptyStars = maxRating - roundedAverage;
 
   // TO DO all ratings equal to zero display as an integer not 0.0
-  // const zero = rating === 0 ? Math.round(zero) : average.toFixed(1);
+  const rating = average === 0 ? roundedAverage : average.toFixed(1);
 
   const renderFullStars = () => {
-    return rating !== 0
-      ? Array(rating)
+    return roundedAverage !== 0
+      ? Array(roundedAverage)
           .fill(null)
           .map((star, i) => {
             return (
@@ -49,10 +74,15 @@ const Rating = (props: ShowProps) => {
   };
 
   return (
-    <div>
+    <RatingContainer display={props.display}>
       <span>{renderFullStars()}</span>
       <span>{renderEmptyStars()}</span>
-    </div>
+      {props.showNumbers && (
+        <NumberRating fontSize={1} mx={2}>
+          {rating} / 5
+        </NumberRating>
+      )}
+    </RatingContainer>
   );
 };
 

--- a/components/Rating.tsx
+++ b/components/Rating.tsx
@@ -1,9 +1,10 @@
-import { TypographyProps, typography } from "styled-system";
+import { SpaceProps, TypographyProps, space, typography } from "styled-system";
 
 import Flex from "./styles/Flex";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faStar } from "@fortawesome/free-solid-svg-icons";
 import styled from "styled-components";
+import { useRouter } from "next/router";
 
 interface ShowProps {
   rating: { average: number | null };
@@ -13,17 +14,28 @@ const NoRating = styled.p<TypographyProps>`
   ${typography};
 `;
 
-const NumberRating = styled.p<TypographyProps>`
+const NumberRating = styled.p<TypographyProps & SpaceProps>`
   ${typography};
+  ${space};
 `;
 
 const Rating = (props: ShowProps) => {
+  const location = useRouter();
+  const hideRating = "/";
+
+  if (hideRating.includes(location.pathname)) {
+    return null;
+  }
   if (props.rating.average === null) {
     return <NoRating fontSize={1}>No rating</NoRating>;
   }
+
   const rating = Math.round(props.rating.average / 2);
   const maxRating = 5;
   const emptyStars = maxRating - rating;
+
+  // TO DO all ratings equal to zero display as an integer not 0.0
+  // const zero = rating === 0 ? Math.round(zero) : average.toFixed(1);
 
   const renderFullStars = () => {
     return rating !== 0
@@ -50,10 +62,13 @@ const Rating = (props: ShowProps) => {
   };
 
   return (
-    <Flex mr={4} flexDirection="row">
+    <Flex flexDirection="row">
+      {" "}
       <span>{renderFullStars()}</span>
       <span>{renderEmptyStars()}</span>
-      <NumberRating fontSize={1}>{rating} / 5</NumberRating>
+      <NumberRating fontSize={1} mx={2}>
+        {rating} / 5
+      </NumberRating>
     </Flex>
   );
 };

--- a/components/ShowHeader.tsx
+++ b/components/ShowHeader.tsx
@@ -48,7 +48,7 @@ const ShowHeader = (props: ShowHeaderProps) => {
         </Link>
         <Flex flexDirection="column" my={4} p={[0, 0, 0, 4]}>
           <Flex flexDirection={["column", "row", "row", "row"]}>
-            <Rating rating={props.rating} />
+            <Rating rating={props.rating} showNumbers />
           </Flex>
           <ShowTitle fontSize={4} my={4}>
             {props.name}

--- a/components/Shows.tsx
+++ b/components/Shows.tsx
@@ -19,6 +19,7 @@ type ShowProps = EpisodeType;
 const Show = (props: ShowProps) => {
   const { show } = props;
   const image = show.image ? show.image.medium : fallbackImage;
+  const responsiveDisplays = ["none", "none", "none", "flex"];
 
   return (
     <Link as={`/shows/${show.id}`} href="/shows/[show]" key={show.url}>
@@ -30,7 +31,7 @@ const Show = (props: ShowProps) => {
             width={414}
             height={639}
           />
-          <Rating rating={show.rating} />
+          <Rating rating={show.rating} display={responsiveDisplays} />
           <p>{show.name}</p>
         </Div>
       </a>


### PR DESCRIPTION
### What changes have you made?
- Passed optional props to the `Rating` component in order to have the numbers and stars display conditionally
- Set the `rating` prop to one decimal place for all numbers except for 0 

### Which issue(s) does this PR fix?
Fixes #63 

### Screenshots (if there are design changes)
<img width="281" alt="Screenshot 2020-12-06 at 19 38 47" src="https://user-images.githubusercontent.com/53219789/101291420-ddfa6300-3808-11eb-8028-f502ceda70a5.png">

<img width="281" alt="Screenshot 2020-12-06 at 21 30 41" src="https://user-images.githubusercontent.com/53219789/101291605-51e93b00-380a-11eb-8b36-1fd1af47100d.png">


### How to test
In the browser the star rating should appear in the following contexts: 
- In number and star form on the show page view (mobile **and** desktop)
- In star form only on the homepage (desktop **only**)
- No rating in star or number form should appear on the homepage (mobile **only**)