### PR TITLE
minor fixes to padding and margins

### DIFF
--- a/components/CastList.tsx
+++ b/components/CastList.tsx
@@ -3,11 +3,13 @@ import {
   ColorProps,
   GridProps,
   LayoutProps,
+  SpaceProps,
   TypographyProps,
   border,
   color,
   grid,
   layout,
+  space,
   typography,
 } from "styled-system";
 
@@ -28,10 +30,11 @@ const Avatar = styled.img`
   height: auto;
 `;
 
-const P = styled.p<TypographyProps & GridProps & ColorProps>`
+const P = styled.p<TypographyProps & GridProps & ColorProps & SpaceProps>`
   ${typography};
   ${grid};
   ${color};
+  ${space};
   display: flex;
   align-self: center;
 `;
@@ -63,8 +66,8 @@ const CastMember = (props: CastMemberProps) => {
         <Grid
           gridTemplateColumns={[
             "65px 120px 120px",
-            "65px 95px 130px",
-            "65px 95px 120px",
+            "65px 120px 120px",
+            "65px 120px 120px",
             "75px 150px 180px",
           ]}
           my={1}
@@ -72,10 +75,10 @@ const CastMember = (props: CastMemberProps) => {
           <CircularPortrait width={50} height={50}>
             <Avatar src={castImage}></Avatar>
           </CircularPortrait>
-          <P gridColumn={2} fontSize={2}>
+          <P gridColumn={2} fontSize={2} mr={1}>
             {castMember}
           </P>
-          <P gridColumn={3} fontSize={2} color="grey">
+          <P gridColumn={3} fontSize={2} color="grey" ml={1}>
             {characterName}
           </P>
         </Grid>

--- a/components/ShowBody.tsx
+++ b/components/ShowBody.tsx
@@ -13,7 +13,7 @@ type ShowBodyProps = {
 
 const ShowBody = (props: ShowBodyProps) => {
   return (
-    <Padding px={[3, 3, 3, 6]}>
+    <Padding px={[3, 6, 6, 6]}>
       <Grid
         gridTemplateColumns={[
           "repeat(1, 100% [col-start])",

--- a/components/ShowHeader.tsx
+++ b/components/ShowHeader.tsx
@@ -39,7 +39,7 @@ interface ShowHeaderProps {
 
 const ShowHeader = (props: ShowHeaderProps) => {
   return (
-    <Padding px={[3, 3, 3, 6]} pb={[0, 0, 0, 6]}>
+    <Padding px={[3, 6, 6, 6]} pb={[0, 0, 0, 6]}>
       <Flex flexDirection={["column", "column", "column", "row"]}>
         <Link href="/">
           <ShowLink>

--- a/components/core/Header.tsx
+++ b/components/core/Header.tsx
@@ -3,7 +3,7 @@ import Padding from "../styles/Padding";
 
 const Header = () => {
   return (
-    <Padding p={[3, 3, 3, 6]}>
+    <Padding p={6}>
       <h2>
         <Link href="/">
           <a>


### PR DESCRIPTION
### What changes have you made?
- Fixed a small inconsistency on the `header` padding
- Improved responsive padding on mobile 
- Tweaked the column widths on the cast list 

### Which issue(s) does this PR fix?
Fixes #59 

### Screenshots (if there are design changes)
No visible design changes

### How to test
Go to the homepage and the show page and check:
- that there is enough padding on mobile and desktop
- there should still be no text overflow on any of the character names in the cast list 