### PR TITLE
creates error message component

### DIFF
--- a/components/ErrorMessage.tsx
+++ b/components/ErrorMessage.tsx
@@ -1,0 +1,39 @@
+import { SpaceProps, TypographyProps, space, typography } from "styled-system";
+
+import Flex from "./styles/Flex";
+import Link from "next/link";
+import React from "react";
+import styled from "styled-components";
+
+const Message = styled.p<TypographyProps>`
+  ${typography}
+`;
+
+const Container = styled.div<SpaceProps>`
+  width: fit-content;
+  position: absolute;
+  top: 10%;
+  ${space};
+`;
+
+const fallback = "https://media.giphy.com/media/LXtjHzZjC5WLu/giphy.gif";
+
+const ErrorMessage = () => {
+  return (
+    <Flex p={6} alignItems="center" flexDirection="column">
+      <Container p={6}>
+        <Flex my={6} flexDirection="column">
+          <Message>Oops, this page isn't available right now.</Message>
+          <Message>Put the kettle on and come back in five.</Message>
+        </Flex>
+        <Link href="/">
+          <a>
+            <img alt="Error image" src={fallback} width={300} height={400} />
+          </a>
+        </Link>
+      </Container>
+    </Flex>
+  );
+};
+
+export default ErrorMessage;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,9 +1,11 @@
 import Container from "../components/core/Container";
 import { EpisodeType } from "./shows/[show]";
+import ErrorMessage from "../components/ErrorMessage";
 import Head from "next/head";
 import Header from "../components/core/Header";
 import Intro from "../components/Intro";
 import Layout from "../components/core/Layout";
+import React from "react";
 
 type EpisodesType = EpisodeType[];
 
@@ -19,7 +21,7 @@ const Home = ({ shows }: ShowsProps) => {
       </Head>
       <Container>
         <Header />
-        {shows ? <Intro shows={shows} /> : "sorry!"}
+        {shows ? <Intro shows={shows} /> : <ErrorMessage />}
       </Container>
     </Layout>
   );

--- a/pages/shows/[show].tsx
+++ b/pages/shows/[show].tsx
@@ -5,7 +5,6 @@ import ErrorPage from "next/error";
 import Head from "next/head";
 import Header from "../../components/core/Header";
 import Layout from "../../components/core/Layout";
-import React from "react";
 import ShowBody from "../../components/ShowBody";
 import ShowHeader from "../../components/ShowHeader";
 import { useRouter } from "next/router";
@@ -76,7 +75,6 @@ const Show = (props: ShowPageProps) => {
 
 Show.getInitialProps = async (ctx: any) => {
   try {
-    throw new Error();
     const res = await fetch(
       `http://api.tvmaze.com/shows/${ctx.query.show}?embed=cast`
     );

--- a/pages/shows/[show].tsx
+++ b/pages/shows/[show].tsx
@@ -1,9 +1,11 @@
 import { CastMemberType } from "../../components/CastList";
 import Container from "../../components/core/Container";
+import ErrorMessage from "../../components/ErrorMessage";
 import ErrorPage from "next/error";
 import Head from "next/head";
 import Header from "../../components/core/Header";
 import Layout from "../../components/core/Layout";
+import React from "react";
 import ShowBody from "../../components/ShowBody";
 import ShowHeader from "../../components/ShowHeader";
 import { useRouter } from "next/router";
@@ -34,7 +36,7 @@ const fallbackImage = "/assets/avatar.jpeg";
 
 const Show = (props: ShowPageProps) => {
   if (!props.show || !props.castList) {
-    return "Sorry, there was an error getting the data here";
+    return <ErrorMessage />;
   }
   const { name, summary, rating, image } = props.show;
 
@@ -74,6 +76,7 @@ const Show = (props: ShowPageProps) => {
 
 Show.getInitialProps = async (ctx: any) => {
   try {
+    throw new Error();
     const res = await fetch(
       `http://api.tvmaze.com/shows/${ctx.query.show}?embed=cast`
     );


### PR DESCRIPTION
### What changes have you made?
- Created an `ErrorMessage` component to be used in the `[show]` and `index` pages 

### Which issue(s) does this PR fix?
Fixes #70 

### Screenshots (if there are design changes)
<img width="267" alt="Screenshot 2020-12-07 at 00 46 04" src="https://user-images.githubusercontent.com/53219789/101296833-f9279b80-3825-11eb-86a4-5279822c4488.png">


### How to test
Apply `throw new Error();` inside of:
- the `try` statement of the `[show]` page:
- the `try` statement of the `index` page:

Make sure the error message appears for both pages and then remove the `throw new Error` to render the content again.

Future feature: Make use of the `useRouter` hook to be able to navigate back to the homepage or the show page. 

Currently the user is only able to navigate back to the homepage when there is no singular `show` data but not if there is no plural `shows` data